### PR TITLE
Fixed the fetch url password exclude bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,19 +42,6 @@
       </releases>
     </repository>
     
-    <repository>
-      <id>jgit-releases</id>
-      <url>http://fisheye4.atlassian.com/browse/~raw,r=trunk/hudson/trunk/hudson/plugins/git/maven-repository</url>
-      <!--
-      <url>https://guest:guest@hudson.dev.java.net/svn/hudson/trunk/hudson/plugins/git/maven-repository</url>
-      -->
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-    </repository>
       <repository>
           <id>guice-maven</id>
           <name>guice maven</name>

--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -160,7 +160,7 @@ public class GitAPI implements IGitAPI {
         }
 
         // Assume only 1 URL for this repository
-        final String source = remoteConfig.getURIs().get(0).toString();
+        final String source = remoteConfig.getURIs().get(0).toPrivateString();
 
         try {
             workspace.act(new FileCallable<String>() {
@@ -388,7 +388,7 @@ public class GitAPI implements IGitAPI {
 
     public void push(RemoteConfig repository, String refspec) throws GitException {
         ArgumentListBuilder args = new ArgumentListBuilder();
-        args.add("push", repository.getURIs().get(0).toString());
+        args.add("push", repository.getURIs().get(0).toPrivateString());
 
         if (refspec != null)
             args.add(refspec);

--- a/src/main/java/hudson/plugins/git/GitAPI.java
+++ b/src/main/java/hudson/plugins/git/GitAPI.java
@@ -540,7 +540,7 @@ public class GitAPI implements IGitAPI {
     public void fetch(RemoteConfig remoteRepository) throws GitException
     {
         // Assume there is only 1 URL / refspec for simplicity
-        fetch(remoteRepository.getURIs().get(0).toString(), remoteRepository.getFetchRefSpecs().get(0).toString());
+        fetch(remoteRepository.getURIs().get(0).toPrivateString(), remoteRepository.getFetchRefSpecs().get(0).toString());
 
     }
 

--- a/src/main/java/hudson/plugins/git/GitSCM.java
+++ b/src/main/java/hudson/plugins/git/GitSCM.java
@@ -341,7 +341,7 @@ public class GitSCM extends SCM implements Serializable {
     {
 	    // Attempt to guess the submodule URL??
 
-        String refUrl = orig.getURIs().get(0).toString();
+        String refUrl = orig.getURIs().get(0).toPrivateString();
 
         if (refUrl.endsWith("/.git"))
         {

--- a/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/git/GitSCM/config.jelly
@@ -22,7 +22,7 @@
            <table width="100%">
            
            <f:entry title="URL of repository">
-            <f:textbox name="git.repo.url" value="${repo.URIs.get(0)}" />
+            <f:textbox name="git.repo.url" value="${repo.URIs.get(0).scheme}://${repo.URIs.get(0).user}:${repo.URIs.get(0).pass}@${repo.URIs.get(0).host}${repo.URIs.get(0).path}" />
            </f:entry>
            
            <f:advanced>


### PR DESCRIPTION
I have a repository over http with username and password embedded in the url. The plugin uses toString method of URIs which ignores the password field of the url. Because of this the commandline waits for a manual password entry in such cases. So I have switched the fetch url from one without password to one with password.
